### PR TITLE
Add CSRF protection to Marketplace POST forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,12 +171,13 @@ def create_otp():
     return str(random.randint(100000,999999))
 
 def send_otp(email, otp):
-    message=Message(subject="OTP for verification", recipients=[email], body="Your one time password (OTP) to login to your GuildSpace account securely is:" + otp)
-    return mail.send(message)
+    print(f"OTP for {email}: {otp}")
+    return True
 
 def create_csrf_token():
+    """Create one CSRF token per browser session and reuse it in all forms."""
     if "csrf_token" not in session:
-        session["csrf_token"]=secrets.token_hex(16)
+        session["csrf_token"] = secrets.token_hex(16)
     return session["csrf_token"]
 
 @app.context_processor
@@ -196,11 +197,12 @@ def inject_common_data():
 
 @app.before_request
 def check_csrf_token():
+    """Block POST requests that do not include the correct CSRF token."""
     if request.method == "POST":
         form_token = request.form.get("csrf_token")
         session_token = session.get("csrf_token")
 
-        if not form_token or form_token != session_token:
+        if not form_token or not session_token or form_token != session_token:
             abort(403)
 
 @app.route("/")
@@ -220,7 +222,6 @@ def forum():
     if not logged_in():
         flash("Please login first.")
         return redirect(url_for("login"))
-    return render_template("forum.html")
     return render_template("forum.html", posts=posts, active_nav="forum")
 
 @app.route("/forum/post", methods=["POST"])
@@ -607,3 +608,4 @@ def logout():
 
 if __name__ == "__main__":
     app.run(debug=True)
+

--- a/templates/marketplace.html
+++ b/templates/marketplace.html
@@ -76,6 +76,7 @@
 
                     {% if item.seller == current_user %}
                     <form action="{{ url_for('update_listing_status', item_id=item.id) }}" method="POST" class="status-form">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <label>Edit status</label>
                         <div>
                             <select name="status">
@@ -112,6 +113,7 @@
                             <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                         </div>
                         <form action="{{ url_for('place_bid', item_id=item.id) }}" method="POST">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <div class="modal-body listing-form compact-form">
                                 <label>Your Name</label>
                                 <input type="text" name="buyer_name" required>

--- a/templates/message_seller.html
+++ b/templates/message_seller.html
@@ -11,6 +11,7 @@
             </div>
 
             <form method="POST" class="listing-form">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <label>Your Name</label>
                 <input type="text" name="name" placeholder="Enter your name" required>
 

--- a/templates/post_listing.html
+++ b/templates/post_listing.html
@@ -10,6 +10,7 @@
         </div>
 
         <form method="POST" enctype="multipart/form-data" class="listing-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <label>Item Title</label>
             <input type="text" name="title" placeholder="Example: Scientific calculator" required>
 


### PR DESCRIPTION
 ## Description

This PR fixes missing CSRF protection in Marketplace forms and updates the OTP testing flow for local development.

## Changes Made

- Added CSRF token to the post listing form
- Added CSRF token to the message seller form
- Added CSRF token to the listing status update form
- Added CSRF token to the bid placement form
- Temporarily prints OTP in the terminal for local testing because email sending is not fully functional yet

## Testing

- Ran `grep -R "csrf_token" templates app.py`
- Confirmed CSRF tokens appear in Marketplace templates
- Tested locally using Flask
- OTP can be checked from the terminal during local testing

## Notes

The terminal OTP output is temporary for development/testing. Email sending can be restored once mail configuration is fixed.