### PR TITLE
Fix marketplace bid modal mouse interaction

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -712,3 +712,34 @@ body {
     box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
 }
 
+/* Fix marketplace bid modal mouse interaction */
+.modal,
+.modal.show {
+    z-index: 3000 !important;
+}
+
+.modal-dialog {
+    position: relative;
+    z-index: 3001 !important;
+    pointer-events: auto !important;
+}
+
+.modal-content {
+    position: relative;
+    z-index: 3002 !important;
+    pointer-events: auto !important;
+}
+
+.modal-content input,
+.modal-content textarea,
+.modal-content select,
+.modal-content button,
+.modal-content label {
+    pointer-events: auto !important;
+}
+
+.modal-backdrop,
+.modal-backdrop.show {
+    z-index: 2990 !important;
+    pointer-events: none !important;
+}


### PR DESCRIPTION
## Summary

This PR fixes the Marketplace Place Bid modal so users can click and fill in the input fields using the mouse.

## Changes made

- Updated modal and backdrop z-index styling
- Enabled pointer events for modal input fields and buttons
- Kept the existing bid backend logic unchanged

## Testing

- Opened Marketplace page
- Clicked Place Bid on a Pending listing
- Confirmed input fields can now be clicked with the mouse
- Confirmed Tab navigation still works
- Confirmed bid submission still works

solve issue #38 