### PR TITLE
Add basic unit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 Flask>=3.0.0
 Werkzeug>=3.0.0
+Flask-SQLAlchemy>=3.1.0
+Flask-Mail>=0.9.1
+pytest>=8.0.0

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,56 @@
+import pytest
+
+from app import app as flask_app, valid_password
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(TESTING=True)
+
+    with flask_app.test_client() as test_client:
+        yield test_client
+
+
+def test_login_page_loads(client):
+    response = client.get("/login")
+    assert response.status_code == 200
+
+
+def test_register_page_loads(client):
+    response = client.get("/register")
+    assert response.status_code == 200
+
+
+def test_root_redirects_to_login(client):
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_home_requires_login(client):
+    response = client.get("/home", follow_redirects=False)
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_forum_requires_login(client):
+    response = client.get("/forum", follow_redirects=False)
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_marketplace_requires_login(client):
+    response = client.get("/marketplace", follow_redirects=False)
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_valid_password_accepts_strong_password():
+    assert valid_password("StrongPass1!") is True
+
+
+def test_valid_password_rejects_weak_passwords():
+    assert valid_password("short1!") is False
+    assert valid_password("NoNumber!") is False
+    assert valid_password("nonumberorspecial") is False
+    assert valid_password("NoSpecial1") is False


### PR DESCRIPTION
## Summary

This PR adds basic unit tests for Flask routes and password validation.

## Tests added

- Login page loads
- Register page loads
- Root route redirects to login
- Home requires login
- Forum requires login
- Marketplace requires login
- Strong password validation passes
- Weak password validation fails

## How to run

```bash
python3 -m pytest tests/test_routes.py -v